### PR TITLE
Snyk fails on npm install for Node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "support": true,
   "devDependencies": {
-    "eslint": "^7.24.0",
+    "eslint": "^8.6.0",
     "eslint-config-semistandard": "^15.0.1",
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-import": "^2.22.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^5.1.0",
+    "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-standard": "^5.0.0",
     "mocha": "^9.1.2",
     "nyc": "^15.1.0",


### PR DESCRIPTION
Snyk fails for node 16 on npm install due to circular dependency between eslint and eslint-plugin-promise. This PR solves this issue without using the --legacy-peer-deps