### PR TITLE
Snyk error with peer dependencies while on npm install

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
+    - run: npm install --legacy-peer-deps
     - run: npm test
     - run: npx @pkgjs/support validate
     - run: node_modules/nyc/bin/nyc.js report --reporter=lcovonly


### PR DESCRIPTION
This happens on npm v7 and later. By adding the option --legacy-peer-deps on `npm i` treats npm modules as on v4 - v6. 