### PR TITLE
chore!: drop Node.js 12

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Would require a semver major bump