### PR TITLE
feat!: remove Node 20 support

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       - run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "standard-version": "^9.5.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "kafka"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "support": true,
   "devDependencies": {


### PR DESCRIPTION
## Node Versions Updated

- Removed Node 20 support
- Updated CI to test on Node 22 and 24
- Updated release workflow to use Node 24 (latest LTS)
- Updated package.json engines to require Node >=22

## Related PR

Related to: https://github.com/nodeshift/kube-service-bindings/pull/288/changes