### PR TITLE
feat!: remove Node 20 support

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       - run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "standard-version": "^9.5.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "kafka"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "support": true,
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Removed Node 20.x from CI matrix (no longer in LTS)
- Updated CI matrix to [22.x, 24.x]
- Updated release workflow to use Node 24 (highest major)
- Updated engines.node to ">=22" (lowest major)

## Reference
Based on the process documented in: https://github.com/nodeshift/kube-service-bindings/pull/288

## Node Version Changes
- **Removed:** Node 20.x (no longer in active LTS)
- **Kept:** Node 22.x, 24.x (current active LTS versions)
- **Not added:** Node 26.x (waiting for 1-month period after start date)