### PR TITLE
feat!: remove Node 20 support

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
 
     steps:
     - uses: actions/checkout@v6

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "kafka"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "support": true,
   "devDependencies": {


### PR DESCRIPTION
This PR updates the Node.js versions to align with the current active LTS versions.

## Changes
- **Removed:** Node.js 20 (no longer in active LTS)
- **Added:** Node.js 26 (now in active LTS as of 2026-05-05)
- **Retained:** Node.js 22, 24

## Files Updated
- `.github/workflows/nodejs-ci-action.yml`: Updated CI matrix from `[20.x, 22.x, 24.x]` to `[22.x, 24.x, 26.x]`
- `package.json`: Updated engines field from `"node": ">=20"` to `"node": ">=22"`