### PR TITLE
Update rmdir command

### DIFF
--- a/test/test-postgresql-bindings/test.js
+++ b/test/test-postgresql-bindings/test.js
@@ -247,7 +247,7 @@ describe('PSQL', () => {
 });
 
 function removeDirectory(sslkey) {
-  fs.rmdir(path.dirname(sslkey), { recursive: true }, (err) => {
+  fs.rm(path.dirname(sslkey), { recursive: true }, (err) => {
     if (err) {
       console.error(err);
     }


### PR DESCRIPTION
`rmdir` is deprecated on node 26