### PR TITLE
feat!: remove Node 20 support

### DIFF
--- a/.github/workflows/nodejs-ci-action.yml
+++ b/.github/workflows/nodejs-ci-action.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 26
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       - run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "standard-version": "^9.5.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "kafka"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "support": true,
   "devDependencies": {


### PR DESCRIPTION
This PR updates Node.js versions to align with the current active LTS releases.

## Changes

**Removed:**
- Node.js 20 (no longer in active LTS)

**Added:**
- Node.js 26 (current LTS)

**Retained:**
- Node.js 22
- Node.js 24

## Updated Files

- `package.json`: Updated `engines.node` from `>=20` to `>=22`
- `.github/workflows/nodejs-ci-action.yml`: Updated CI matrix from `[20.x, 22.x, 24.x]` to `[22.x, 24.x, 26.x]`
- `.github/workflows/release-please.yml`: Updated release Node version from `22` to `26`
- `package-lock.json`: Regenerated via `npm install`

This is a breaking change as Node.js 20 support is being removed.